### PR TITLE
Make routing key behaviour more clear in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,11 +97,11 @@ have the exchange called `shard.images`, we could define the following
 policy to shard it:
 
 ```bash
-$CTL set_policy images-shard "^shard.images$" '{"shards-per-node": 2, "routing-key": "1234"}'
+$CTL set_policy images-shard "^shard.images$" '{"shards-per-node": 2, "routing-key": "ignored"}'
 ```
 
 This will create `2` sharded queues per node in the cluster, and will
-bind those queus using the `"1234"` routing key.
+bind those queus using the `"ignored"` routing key.
 
 ## Building the plugin ##
 


### PR DESCRIPTION
If I understand it correctly the routing-key in the policy is ignored by this exchange. Using the routing key "1234" confused me for a bit - I initially thought there was something special about "1234".

I think it would make sense to call it "ignored", the fact it is ignored should be somewhat intuitive and if it isn't you use the word "ignored" in the documentation (making it easier to make the connection).