### PR TITLE
Adjust error message to reflect the code

### DIFF
--- a/src/rabbit_sharding_policy_validator.erl
+++ b/src/rabbit_sharding_policy_validator.erl
@@ -58,7 +58,7 @@ validate_shards_per_node(Term) when is_number(Term) ->
         true  ->
             ok;
         false ->
-            {error, "shards-per-node should be greater than 0, actually was ~p",
+            {error, "shards-per-node should be non-negative, actually was ~p",
              [Term]}
     end;
 validate_shards_per_node(Term) ->


### PR DESCRIPTION
Condition tests number for being non-negative (>= 0), yet the error message tells the user it must be positive (> 0). However, maybe the message is correct but the code is not.