### PR TITLE
Ignore queue master locator

### DIFF
--- a/src/rabbit_sharding_shard.erl
+++ b/src/rabbit_sharding_shard.erl
@@ -94,7 +94,7 @@ declare_queue(XName, Durable, N, Node) ->
     QBin = make_queue_name(exchange_bin(XName), a2b(Node), N),
     QueueName = rabbit_misc:r(v(XName), queue, QBin),
     try rabbit_amqqueue:declare(QueueName, Durable, false, [], none,
-                                ?SHARDING_USER, Node) of
+                                ?SHARDING_USER, {ignore_location, Node}) of
         {_Reply, _Q} ->
             ok
     catch


### PR DESCRIPTION
If a queue-master-locator policy is set, the shards might not end up in the required nodes. This change overrides it by using an `ignore_location` tag on the node argument of queue declare, so the shards are always created where requested. It depends on https://github.com/rabbitmq/rabbitmq-server/pull/2139

Closes #30 